### PR TITLE
Fixing exploit using extract() function

### DIFF
--- a/admin/classes/Credentials.php
+++ b/admin/classes/Credentials.php
@@ -54,7 +54,12 @@ class Credentials
 //PRINT_R($c->loginAdmin("rizwan@gmail.com", "12345"));
 
 if (isset($_POST['admin_register'])) {
-	extract($_POST);
+	// extract($_POST);
+	$name  = $_POST['name'];
+	$email = $_POST['email'];
+	$password = $_POST['password'];
+	$cpassword = $_POST['cpassword'];
+
 	if (!empty($name) && !empty($email) && !empty($password) && !empty($cpassword)) {
 		if ($password == $cpassword) {
 			$c = new Credentials();
@@ -72,7 +77,9 @@ if (isset($_POST['admin_register'])) {
 }
 
 if (isset($_POST['admin_login'])) {
-	extract($_POST);
+	// extract($_POST);
+	$email = $_POST['name'];
+	$password = $_POST['password'];
 	if (!empty($email) && !empty($password)) {
 		$c = new Credentials();
 		$result = $c->loginAdmin($email, $password);


### PR DESCRIPTION
Hi! I was looking for projects on github that use the "extract()" function so see if these site were exploitable or not. In this case, I found a bug or security issue on the login that can be exploited to give access to anyone by only sending an extra parameter in the POST request called "_SESSION[admin_id]", overwriting this variable that controls if an user is logged in.
The extract function can be used to overwrite variables, even the session one ($_SESSION). If this is possible, for example, a person could overwrite $_SESSION[admin_id] with any value, and could log in to the site without knowing any password or username.
To avoid this issue, is necessary to assign variables one-to-one like this:
```
$username=$_POST['username'];
$password=$_POST['password'];
```
Or using some flag as a second parameter on the extract() function, but this is not really recommended.
The php documentation about this problem is here: [documentation](https://www.php.net/manual/es/function.extract.php)

cya!
